### PR TITLE
 #2: update npm metadata to point to this repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "main.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kirontoo/insomnia-plugin-embark-theme.git"
+    "url": "git+https://github.com/embark-theme/insomnia.git"
   },
   "insomnia": {
     "name": "theme-embark",
@@ -24,7 +24,7 @@
   "author": "kirontoo",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/kirontoo/insomnia-plugin-embark-theme/issues"
+    "url": "https://github.com/embark-theme/insomnia/issues"
   },
-  "homepage": "https://github.com/kirontoo/insomnia-plugin-embark-theme#readme"
+  "homepage": "https://github.com/embark-theme/insomnia#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "insomnia-plugin-embark-theme",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "An Insomnia theme for the ambitious",
   "main": "main.js",
   "repository": {


### PR DESCRIPTION
I've changed all links from `kirontoo/insomnia-plugin-embark-theme` to `embark-theme/insomnia`. 

I've published the package and you can see the changes reflected at: https://www.npmjs.com/package/insomnia-plugin-embark-theme

reference issue: #2 